### PR TITLE
fix: typescript compilation errors

### DIFF
--- a/src/DisplayDelegate.ts
+++ b/src/DisplayDelegate.ts
@@ -1,4 +1,4 @@
-import { StarIO10Error } from "./StarIO10Error";
+import type { StarIO10Error } from "./StarIO10Error";
 
 export class DisplayDelegate {
     _onEventSet: () => void = () => {};

--- a/src/DrawerDelegate.ts
+++ b/src/DrawerDelegate.ts
@@ -1,4 +1,4 @@
-import { StarIO10Error } from "./StarIO10Error";
+import type { StarIO10Error } from "./StarIO10Error";
 
 export class DrawerDelegate {
     _onEventSet: () => void = () => {};
@@ -6,7 +6,7 @@ export class DrawerDelegate {
     private _onOpenCloseSignalSwitched: (openCloseSignal: boolean) => void = () => {};
 
     onCommunicationError: (error: StarIO10Error) => void = () => {};
-    
+
     set onOpenCloseSignalSwitched(value: (openCloseSignal: boolean) => void) {
         this._onOpenCloseSignalSwitched = value;
 

--- a/src/InputDeviceDelegate.ts
+++ b/src/InputDeviceDelegate.ts
@@ -1,4 +1,4 @@
-import { StarIO10Error } from "./StarIO10Error";
+import type { StarIO10Error } from "./StarIO10Error";
 
 export class InputDeviceDelegate {
     _onEventSet: () => void = () => {};

--- a/src/PrinterDelegate.ts
+++ b/src/PrinterDelegate.ts
@@ -1,4 +1,4 @@
-import { StarIO10Error } from "./StarIO10Error";
+import type { StarIO10Error } from "./StarIO10Error";
 
 export class PrinterDelegate {
     _onEventSet: () => void = () => {};

--- a/src/StarDeviceDiscoveryManager.ts
+++ b/src/StarDeviceDiscoveryManager.ts
@@ -8,7 +8,7 @@ import { NativeObject } from './NativeObject';
 import { StarConnectionSettings } from './StarConnectionSettings';
 import { StarPrinter } from './StarPrinter';
 import { StarIO10ErrorFactory } from './StarIO10ErrorFactory';
-import { InterfaceType } from './InterfaceType';
+import type { InterfaceType } from './InterfaceType';
 import { StarPrinterInformation } from './StarPrinterInformation';
 
 const eventEmitter = new NativeEventEmitter(NativeModules.StarDeviceDiscoveryManagerWrapper);

--- a/src/StarDeviceDiscoveryManagerFactory.ts
+++ b/src/StarDeviceDiscoveryManagerFactory.ts
@@ -2,7 +2,7 @@ import {
     NativeModules
 } from 'react-native';
 import { StarDeviceDiscoveryManager } from './StarDeviceDiscoveryManager';
-import { InterfaceType } from './InterfaceType';
+import type { InterfaceType } from './InterfaceType';
 import { StarIO10ErrorFactory } from './StarIO10ErrorFactory';
 
 export class StarDeviceDiscoveryManagerFactory {

--- a/src/StarIO10ErrorFactory.ts
+++ b/src/StarIO10ErrorFactory.ts
@@ -9,8 +9,8 @@ import { StarIO10NotFoundError } from './StarIO10NotFoundError';
 import { StarIO10UnknownError } from './StarIO10UnknownError';
 import { StarIO10UnprintableError } from './StarIO10UnprintableError';
 import { StarPrinterStatusFactory } from './StarPrinterStatusFactory';
-import { StarIO10Error } from './StarIO10Error';
-import { StarPrinterStatus } from './StarPrinterStatus';
+import type { StarIO10Error } from './StarIO10Error';
+import type { StarPrinterStatus } from './StarPrinterStatus';
 
 export class StarIO10ErrorFactory {
     static async create(identifier: String): Promise<StarIO10Error> {

--- a/src/StarIO10Logger.ts
+++ b/src/StarIO10Logger.ts
@@ -48,5 +48,5 @@ export class StarIO10Logger extends NativeObject {
         return `dammy`;
     }
 
-    protected async _disposeNativeObjectImpl(nativeObject: string): Promise<void> {}
+    protected async _disposeNativeObjectImpl(): Promise<void> {}
 }

--- a/src/StarIO10UnprintableError.ts
+++ b/src/StarIO10UnprintableError.ts
@@ -1,5 +1,5 @@
 import { StarIO10Error } from './StarIO10Error';
-import { StarPrinterStatus } from './StarPrinterStatus';
+import type { StarPrinterStatus } from './StarPrinterStatus';
 
 export class StarIO10UnprintableError extends StarIO10Error {
     private _status: StarPrinterStatus | undefined;

--- a/src/StarPrinter.ts
+++ b/src/StarPrinter.ts
@@ -5,10 +5,10 @@ import {
 } from 'react-native';
 
 import { NativeObject } from './NativeObject';
-import { StarConnectionSettings } from './StarConnectionSettings';
+import type { StarConnectionSettings } from './StarConnectionSettings';
 import { StarPrinterInformation } from './StarPrinterInformation';
 import { StarIO10ErrorFactory } from './StarIO10ErrorFactory';
-import { StarPrinterStatus } from './StarPrinterStatus';
+import type { StarPrinterStatus } from './StarPrinterStatus';
 import { StarPrinterStatusFactory } from './StarPrinterStatusFactory';
 import { PrinterDelegate } from './PrinterDelegate';
 import { DrawerDelegate } from './DrawerDelegate';

--- a/src/StarXpandCommand/Bezel/LedAutomaticBlinkParameter.ts
+++ b/src/StarXpandCommand/Bezel/LedAutomaticBlinkParameter.ts
@@ -1,4 +1,4 @@
-import { LedType } from './LedType';
+import type { LedType } from './LedType';
 
 export class LedAutomaticBlinkParameter {
     private _type: LedType;

--- a/src/StarXpandCommand/BezelSettingBuilder.ts
+++ b/src/StarXpandCommand/BezelSettingBuilder.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class BezelSettingBuilder extends BaseStarXpandCommandBuilder {
     settingAutomaticPageLength(enable: boolean): BezelSettingBuilder {

--- a/src/StarXpandCommand/BuzzerBuilder.ts
+++ b/src/StarXpandCommand/BuzzerBuilder.ts
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class BuzzerBuilder extends BaseStarXpandCommandBuilder {
     actionDrive(parameter: StarXpandCommand.Buzzer.DriveParameter): BuzzerBuilder {

--- a/src/StarXpandCommand/DisplayBuilder.ts
+++ b/src/StarXpandCommand/DisplayBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class DisplayBuilder extends BaseStarXpandCommandBuilder {
     styleInternationalCharacter(type: StarXpandCommand.Display.InternationalCharacterType): DisplayBuilder {

--- a/src/StarXpandCommand/DocumentBuilder.ts
+++ b/src/StarXpandCommand/DocumentBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class DocumentBuilder extends BaseStarXpandCommandBuilder {
     settingTopMargin(height: number): DocumentBuilder {

--- a/src/StarXpandCommand/DrawerBuilder.ts
+++ b/src/StarXpandCommand/DrawerBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class DrawerBuilder extends BaseStarXpandCommandBuilder {
     actionOpen(parameter: StarXpandCommand.Drawer.OpenParameter): DrawerBuilder {

--- a/src/StarXpandCommand/MelodySpeaker/DriveRegisteredSoundParameter.ts
+++ b/src/StarXpandCommand/MelodySpeaker/DriveRegisteredSoundParameter.ts
@@ -1,7 +1,7 @@
-import { SoundStorageArea } from './SoundStorageArea';
+import type { SoundStorageArea } from './SoundStorageArea';
 
 export class DriveRegisteredSoundParameter {
-    private _area: SoundStorageArea; 
+    private _area: SoundStorageArea;
     private _number: number;
     private _volume: number = -1;
 

--- a/src/StarXpandCommand/MelodySpeakerBuilder.ts
+++ b/src/StarXpandCommand/MelodySpeakerBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class MelodySpeakerBuilder extends BaseStarXpandCommandBuilder {
     actionDriveRegisteredSound(parameter: StarXpandCommand.MelodySpeaker.DriveRegisteredSoundParameter): MelodySpeakerBuilder {

--- a/src/StarXpandCommand/PageModeBuilder.ts
+++ b/src/StarXpandCommand/PageModeBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class PageModeBuilder extends BaseStarXpandCommandBuilder {
     stylePrintDirection(direction: StarXpandCommand.Printer.PageModePrintDirection): PageModeBuilder {

--- a/src/StarXpandCommand/PreSettingBuilder.ts
+++ b/src/StarXpandCommand/PreSettingBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class PreSettingBuilder extends BaseStarXpandCommandBuilder {
     addPresenterSetting(builder: StarXpandCommand.PresenterSettingBuilder): PreSettingBuilder {

--- a/src/StarXpandCommand/Presenter/LedAutomaticBlinkParameter.ts
+++ b/src/StarXpandCommand/Presenter/LedAutomaticBlinkParameter.ts
@@ -1,4 +1,4 @@
-import { LedType } from './LedType';
+import type { LedType } from './LedType';
 
 export class LedAutomaticBlinkParameter {
     private _type: LedType;

--- a/src/StarXpandCommand/PresenterSettingBuilder.ts
+++ b/src/StarXpandCommand/PresenterSettingBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class PresenterSettingBuilder extends BaseStarXpandCommandBuilder {
     settingMode(parameter: StarXpandCommand.Presenter.ModeParameter): PresenterSettingBuilder {

--- a/src/StarXpandCommand/Printer/BarcodeParameter.ts
+++ b/src/StarXpandCommand/Printer/BarcodeParameter.ts
@@ -1,4 +1,4 @@
-import { BarcodeSymbology } from './BarcodeSymbology';
+import type { BarcodeSymbology } from './BarcodeSymbology';
 import { BarcodeBarRatioLevel } from './BarcodeBarRatioLevel';
 
 export class BarcodeParameter {
@@ -49,7 +49,7 @@ export class BarcodeParameter {
 
         return this;
     }
-    
+
     setBarRatioLevel(barRatioLevel: BarcodeBarRatioLevel): BarcodeParameter {
         this._barRatioLevel = barRatioLevel;
 

--- a/src/StarXpandCommand/PrinterBuilder.ts
+++ b/src/StarXpandCommand/PrinterBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class PrinterBuilder extends BaseStarXpandCommandBuilder {
     styleAlignment(alignment: StarXpandCommand.Printer.Alignment): PrinterBuilder {

--- a/src/StarXpandCommand/StarXpandCommandBuilder.ts
+++ b/src/StarXpandCommand/StarXpandCommandBuilder.ts
@@ -1,7 +1,7 @@
 import { NativeModules } from 'react-native';
 import { BaseStarXpandCommandBuilder } from './BaseStarXpandCommandBuilder';
 import { StarIO10ErrorFactory } from '../StarIO10ErrorFactory';
-import { StarXpandCommand } from '../../index';
+import type { StarXpandCommand } from '../../index';
 
 export class StarXpandCommandBuilder extends BaseStarXpandCommandBuilder {
     private _preSetting?: StarXpandCommand.PreSettingBuilder;


### PR DESCRIPTION
Fixes multiple build errors when using [importsNotUsedAsValues](https://www.typescriptlang.org/tsconfig#importsNotUsedAsValues) `"error"` 
Fixes one build error when using [noUnusedLocals](https://www.typescriptlang.org/tsconfig#noUnusedLocals) `true`

Also available as patch with [patch-package](https://www.npmjs.com/package/patch-package): https://gist.github.com/jesperjohansson/a7e220af983bbf106918d97439819bdc