### PR TITLE
fix: bridge not set crash on reload

### DIFF
--- a/ios/StarDeviceDiscoveryManager/StarDeviceDiscoveryManagerWrapper.m
+++ b/ios/StarDeviceDiscoveryManager/StarDeviceDiscoveryManagerWrapper.m
@@ -145,7 +145,7 @@ RCT_REMAP_METHOD(stopDiscovery,
 - (void)managerDidFinishDiscovery:(id<STARIO10StarDeviceDiscoveryManager> _Nonnull)manager {
     NSString* objID = [_objManager getExsitingIdentifier:manager];
     
-    if (objID) {
+    if (objID && [self bridge] != nil) {
         [self sendEventWithName:kNameDiscoveryFinished body:@{kKeyIdentifier: objID}];
     }
 }


### PR DESCRIPTION
Fixes crash on React Native reload that would occur sometimes:
```
*** Assertion failure in -[RCTEventEmitter sendEventWithName:body:](), react-native/React/Modules/RCTEventEmitter.m:58
```
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Error when sending event: DiscoveryFinished with body: {
    identifier = "ACFA2001-ABC5-51C4-B125-323B1468CB2A";
}. Bridge is not set. This is probably because you've explicitly synthesized the bridge in StarDeviceDiscoveryManagerWrapper, even though it's inherited from RCTEventEmitter.'
```