### PR TITLE
Remove jcenter references

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
@@ -53,7 +52,6 @@ android {
 
 repositories {
     mavenCentral()
-    jcenter()
     google()
 
     def found = false

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath('com.android.tools.build:gradle:4.2.2')
@@ -33,7 +32,6 @@ allprojects {
 
         google()
         mavenCentral()
-        jcenter()
         maven { url 'https://www.jitpack.io' }
     }
 }


### PR DESCRIPTION
jcenter has shutdown as of May 1st
https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

Because of this, `npx react-native run-android` fails with the following error

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Could not resolve org.webkit:android-jsc:+.
     Required by:
         project :app
      > Failed to list versions for org.webkit:android-jsc.
         > Unable to load Maven meta-data from https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml.
            > Could not HEAD 'https://jcenter.bintray.com/org/webkit/android-jsc/maven-metadata.xml'.
               > Read timed out
```

We should remove all references to jcenter to ensure we can continue to build this project on Android.