### PR TITLE
fix: support android sdk 25 and up

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
     compileSdk getExtOrIntegerDefault('compileSdkVersion')
     buildToolsVersion getExtOrDefault('buildToolsVersion')
     defaultConfig {
-        minSdkVersion 28
+        minSdkVersion 25
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
         versionCode 1
         versionName "1.8.0"


### PR DESCRIPTION
I saw that support for older devices was dropped a while back.

We are running our app on Sunmi P2Pro devices, which only support up to sdk 25. We have been running 1.8.0 now for a while, with a patch for changing the minSDK verison with no problems. 

I see no reason why the main package can't support sdk 25.